### PR TITLE
Support to multi ips into a remote host field

### DIFF
--- a/apache.go
+++ b/apache.go
@@ -16,7 +16,7 @@ type Apache struct {
 }
 
 var logRe = regexp.MustCompile(
-	`^(?:([\S.,\s]+)\s)?` + // %v(The canonical ServerName/virtual host) - 192.168.0.1 or 192.168.0.1,192.168.0.2, 192.168.0.3
+	`^(?:([\S,\s]+)\s)?` + // %v(The canonical ServerName/virtual host) - 192.168.0.1 or 192.168.0.1,192.168.0.2, 192.168.0.3
 		`(\S+)\s` + // %h(Remote Hostname) $remote_addr
 		`(\S+)\s` + // %l(Remote Logname)
 		`(\S+)\s` + // $remote_user

--- a/apache.go
+++ b/apache.go
@@ -16,7 +16,7 @@ type Apache struct {
 }
 
 var logRe = regexp.MustCompile(
-	`^(?:(\S+)\s)?` + // %v(The canonical ServerName/virtual host)
+	`^(?:([\S.,\s]+)\s)?` + // %v(The canonical ServerName/virtual host) - 192.168.0.1 or 192.168.0.1,192.168.0.2, 192.168.0.3
 		`(\S+)\s` + // %h(Remote Hostname) $remote_addr
 		`(\S+)\s` + // %l(Remote Logname)
 		`(\S+)\s` + // $remote_user

--- a/apache_test.go
+++ b/apache_test.go
@@ -74,7 +74,7 @@ func TestParse_error(t *testing.T) {
 	for _, tt := range parseSuccessTests {
 		t.Logf("testing: %s", tt.Name)
 		if _, err := psr.Parse(tt.Input); err != nil {
-			t.Errorf("%s: error should not be occured but: %s", err.Error())
+			t.Errorf("%s: error should not be occured but: %s", tt.Name, err.Error())
 		}
 	}
 }

--- a/apache_test.go
+++ b/apache_test.go
@@ -24,6 +24,16 @@ func BenchmarkApache_Parse(b *testing.B) {
 	}
 }
 
+var parseSuccessTests = []struct {
+	Name  string
+	Input string
+}{
+	{
+		Name:  "Valid request - many remote host ips",
+		Input: `192.168.0.1, 192.168.0.2, 192.168.0.3 10.10.10.10 - - [01/Jan/2005:15:04:05 +0000] "GET /home HTTP/1.1" 200 4589 "https://www.google.com/home" "UA"`,
+	},
+}
+
 var parseErrorTests = []struct {
 	Name           string
 	Input          string
@@ -59,6 +69,12 @@ func TestParse_error(t *testing.T) {
 			t.Errorf("%s: error should be occured but nil", tt.Name)
 		} else if !strings.Contains(err.Error(), tt.ContainsString) {
 			t.Errorf("%s: error should be contained %q, but: %s", tt.Name, tt.ContainsString, err)
+		}
+	}
+	for _, tt := range parseSuccessTests {
+		t.Logf("testing: %s", tt.Name)
+		if _, err := psr.Parse(tt.Input); err != nil {
+			t.Errorf("%s: error should not be occured but: %s", err.Error())
 		}
 	}
 }


### PR DESCRIPTION
**Update apache.go**

So, the old regex allows us to identify this pattern:
`192.168.0.1 10.10.10.10 - - [01/Jan/2005:15:04:05 +0000] "GET /home HTTP/1.1" 200 4589 "https://www.google.com/home" "UA"`

But when we identify this situatuion:

`192.168.0.1, 192.168.0.2 10.10.10.10 - - [01/Jan/2005:15:04:05 +0000] "GET /home HTTP/1.1" 200 4589 "https://www.google.com/home" "UA"`

It now works anymore.

With this single change this awesome project just works very well in such situation.