### PR TITLE
Ignore LTSV unmarshal error if loose

### DIFF
--- a/ltsv.go
+++ b/ltsv.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Songmu/go-ltsv"
+	ltsv "github.com/Songmu/go-ltsv"
 	"github.com/pkg/errors"
 )
 
@@ -20,7 +20,9 @@ func (lv *LTSV) Parse(line string) (*Log, error) {
 	l := &Log{}
 	err := ltsv.Unmarshal([]byte(line), l)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse ltsvlog (not a ltsv): %s", line)
+		if _, ok := err.(ltsv.UnmarshalError); !(lv.Loose && ok) {
+			return nil, errors.Wrapf(err, "failed to parse ltsvlog (not a ltsv): %s", line)
+		}
 	}
 	l.Time, _ = time.Parse(clfTimeLayout, strings.Trim(l.TimeStr, "[]"))
 	if err := l.breakdownRequest(); !lv.Loose && err != nil {

--- a/ltsv_test.go
+++ b/ltsv_test.go
@@ -30,6 +30,20 @@ var parseLTSVErrorTests = []struct {
 			"vhost:mackerel.io",
 		ContainsString: "(invalid request)",
 	},
+	{
+		Name: "unmarshal error",
+		Input: "time:08/Mar/2017:14:12:40 +0900\t" +
+			"host:192.0.2.1\t" +
+			"req:POST /api/v0/tsdb HTTP/1.1\t" +
+			"status:200\t" +
+			"size:36\t" +
+			"ua:mackerel-agent/0.31.2 (Revision 775fad2)\t" +
+			"reqtime:0.087\t" +
+			"taken_sec:0.087\t" +
+			"vhost:mackerel.io\t" +
+			"apptime:0.021, 0.042", // not a single number
+		ContainsString: "ltsv: cannot unmarshal",
+	},
 }
 
 func TestLTSV_ParseError(t *testing.T) {


### PR DESCRIPTION
Ref: #19

This PR makes the LTSV log parser to allow logs to contain fields that could not be unmarshaled when `Loose: true`.
Such fields are just ignored, and will have empty / invalid values.
